### PR TITLE
Bugfix/nvidia update

### DIFF
--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -9,8 +9,7 @@
 FROM cogrob/omnimapper-demo
 MAINTAINER Cognitive Robotics "http://cogrob.org/"
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y \
+RUN sudo apt-get update && sudo apt-get install -y \
 	x-window-system \
 	binutils \
 	mesa-utils \

--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -1,5 +1,5 @@
 #From inside this folder
-# docker build -t cogrob/omnimapper-nvidia .
+docker build -t cogrob/omnimapper-nvidia .
 
 ############################################################
 # Dockerfile to build OmiMapper images
@@ -9,6 +9,7 @@
 FROM cogrob/omnimapper-demo
 MAINTAINER Cognitive Robotics "http://cogrob.org/"
 
+RUN sudo apt-get update
 RUN sudo apt-get install -y \
 	x-window-system \
 	binutils \

--- a/docker/nvidia/Dockerfile
+++ b/docker/nvidia/Dockerfile
@@ -1,5 +1,5 @@
 #From inside this folder
-docker build -t cogrob/omnimapper-nvidia .
+#docker build -t cogrob/omnimapper-nvidia .
 
 ############################################################
 # Dockerfile to build OmiMapper images


### PR DESCRIPTION
When I attempted to use the nvidia patch it wouldn't install xserver because of some updates that ubuntu made to the versions available. Thus I added  apt-get update so that a proper install could be made. 